### PR TITLE
fix: validate action=GOOD before triggering graphics (v1.1.1-alpha.1)

### DIFF
--- a/xstats_autotrigger/watcher.py
+++ b/xstats_autotrigger/watcher.py
@@ -83,6 +83,12 @@ class XMLWatcher(threading.Thread):
         self.state.processed_keys.add(key)
         logging.debug("New play detected: %s", key)
 
+        # Only trigger on made shots
+        action = p.get("action")
+        if action != "GOOD":
+            logging.debug("Skipping non-scoring play: action=%s", action)
+            return
+
         stat = self._canon(p.get("type"))
         vh = p.get("vh")
         uni = p.get("uni")


### PR DESCRIPTION
Fixes #3

Critical bug fix discovered in beta v1.1.0 where graphics would trigger on both made AND missed shots. Now validates action="GOOD" before firing any XPression commands.

Changes:
- Add action field validation in _handle_play() at line 87-90
- Only trigger player/team graphics when action="GOOD"
- Skip all non-scoring plays (MISS, FOUL, TURNOVER, SUB, etc.)

Impact:
- Prevents incorrect graphics from appearing on missed shots
- Maintains proper deduplication for all play types
- Preserves existing rate limiting and timing behavior